### PR TITLE
added dataSource to loadAfter

### DIFF
--- a/JmsGrailsPlugin.groovy
+++ b/JmsGrailsPlugin.groovy
@@ -32,7 +32,7 @@ class JmsGrailsPlugin {
     def title = "JMS integration for Grails"
     def grailsVersion = "1.2.0 > *"
 
-    def loadAfter = ['services', 'controllers']
+    def loadAfter = ['services', 'controllers','dataSource','hibernate', 'hibernate4']
     def observe = ['services', 'controllers']
 
     def pluginExcludes = [


### PR DESCRIPTION
A consumer with persistenceInterceptorBean on it's adapter config could
receive a message when the persistencelayer is not fully loaded. I think
loading the plugin after dataSource solves this problem. To make sure
I've added hibernate and hibernate4 as well.